### PR TITLE
php 8.1 in checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,30 @@ on:
             - "*"
 
 jobs:
+    php81:
+        name: "php 8.1"
+        runs-on: ubuntu-latest
+        container: "nofutur3/php-tests:8.1"
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install dependencies
+              run: composer install --no-interaction
+            - name: Phpstan has to be added in pipeline bc it requires PHP 7.1+
+              run: composer require phpstan/phpstan --dev --no-interaction
+            - name: Old phpunit compatibility for php 8
+              run: composer require christiaanbye/polyfill-each --dev --no-interaction
+
+            - name: Check code style
+              run: composer cs-check
+
+            - name: Run static analysis
+              run: composer stan
+
+            - name: Run tests
+              run: composer test81
+
     php80:
         name: "php 8.0"
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
         "test": [
             "vendor/bin/phpunit tests --log-junit ./test-reports/junit.xml"
         ],
+        "test81": [
+            "php -d \"error_reporting=E_ALL&~E_DEPRECATED\" vendor/bin/phpunit tests --log-junit ./test-reports/junit.xml"
+        ],
         "stan7": [
             "vendor/bin/phpstan analyse -c phpstan7.neon --memory-limit=1G"
         ],

--- a/src/Model/Collection/Collection.php
+++ b/src/Model/Collection/Collection.php
@@ -43,6 +43,7 @@ abstract class Collection implements \ArrayAccess, \Iterator
      * @param TValue $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -56,6 +57,7 @@ abstract class Collection implements \ArrayAccess, \Iterator
      * @param string|int $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
@@ -64,6 +66,7 @@ abstract class Collection implements \ArrayAccess, \Iterator
     /**
      * @param string|int $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);
@@ -81,6 +84,7 @@ abstract class Collection implements \ArrayAccess, \Iterator
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorPosition = 0;
@@ -105,6 +109,7 @@ abstract class Collection implements \ArrayAccess, \Iterator
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->iteratorPosition;
@@ -113,6 +118,7 @@ abstract class Collection implements \ArrayAccess, \Iterator
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->data[$this->iteratorPosition]);


### PR DESCRIPTION
http://redmine.havelholding.cz/issues/1951
Finally we have at least partial PHP 8.1 checks, in unit tests are disabled deprecated errors, because we use old phpunit.