### PR TITLE
6910 - Update GitHub Actions workflows to use actions/checkout@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,176 +6,24 @@ on:
             - "**"
 
 jobs:
-    php84:
-        name: "php 8.4"
+    php-tests:
+        name: php ${{ matrix.php-version }}
         runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.4"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
 
-            -   name: Install dependencies
-                run: composer install
-
-            -   name: Run static analysis
-                run: composer stan
-
-            -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            -   name: Run tests
-                run: composer test
-
-    php83:
-        name: "php 8.3"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.3"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v4
-
-            -   name: Install dependencies
-                run: composer install
-
-            -   name: Run static analysis
-                run: composer stan
-
-            -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            -   name: Run tests
-                run: composer test
-
-    php82:
-        name: "php 8.2 psr/http-message 2.0"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.2"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v3
-
-            -   name: Install dependencies
-                run: composer update --no-interaction --with psr/http-message:^2.0
-
-            -   name: Check code style
-                run: composer cs-check
-
-            -   name: Run static analysis
-                run: composer stan
-
-            -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            -   name: Run tests
-                run: composer test
-
-    php82psrmessage10:
-        name: "php 8.2 psr/http-message 1.0"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.2"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v3
-
-            -   name: Install dependencies
-                run: composer update --no-interaction --with psr/http-message:^1.0
-
-            -   name: Run static analysis
-                run: composer stan
-
-            -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            -   name: Run tests
-                run: composer test
-
-    php81:
-        name: "php 8.1"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.1"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-
-            - name: Install dependencies
-              run: composer install --no-interaction
-
-            - name: Run static analysis
-              run: composer stan
-
-            - name: Create mock server from our production OpenAPI
-              run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            - name: Run tests
-              run: composer test
-
-    php80:
-        name: "php 8.0"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.0"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-
-            - name: Install dependencies
-              run: composer install --no-interaction
-
-            - name: Run static analysis
-              run: composer stan
-
-            - name: Create mock server from our production OpenAPI
-              run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            - name: Run tests
-              run: composer test
-
-    php74:
-        name: "php 7.4"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:7.4"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            # Deprecation example for future support removal.
-            #
-            #-   name: Deprecation check (2023-01-01T00:00:00+01:00)
-            #    run: if [ "$(date +%s)" -gt "1672527600" ]; then echo "This PHP version support ended"; exit1; else echo "Deprecation OK"; fi
-
-            -   name: Checkout repository
-                uses: actions/checkout@v3
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+                    coverage: none
+                    extensions: mbstring, intl, curl
 
             -   name: Install dependencies
                 run: composer install --no-interaction
@@ -183,8 +31,72 @@ jobs:
             -   name: Run static analysis
                 run: composer stan
 
+            -   name: Start mock server
+                run: docker run -d -p 1080:1080 mockserver/mockserver
+
+            -   name: Wait for MockServer
+                run: |
+                    for i in {1..20}; do
+                      if curl -s http://localhost:1080/status > /dev/null; then
+                        echo "MockServer is ready"
+                        exit 0
+                      fi
+                      echo "Waiting for MockServer..."
+                      sleep 1
+                    done
+                    echo "MockServer did not start in time"
+                    exit 1
+
             -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
+                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://localhost:1080/mockserver/openapi
+
+            -   name: Run tests
+                run: composer test
+
+    php-with-psr-tests:
+        name: php ${{ matrix.php-version }} psr/http-message ${{ matrix.psr-http-message-version }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: ['8.2']
+                psr-http-message-version: ['1.0', '2.0']
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v6
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+                    coverage: none
+                    extensions: mbstring, intl, curl
+
+            -   name: Install dependencies
+                run: composer update --no-interaction --with psr/http-message:^${{ matrix.psr-http-message-version }}
+
+            -   name: Run static analysis
+                run: composer stan
+
+            -   name: Start mock server
+                run: docker run -d -p 1080:1080 mockserver/mockserver
+
+            -   name: Wait for MockServer
+                run: |
+                    for i in {1..20}; do
+                      if curl -s http://localhost:1080/status > /dev/null; then
+                        echo "MockServer is ready"
+                        exit 0
+                      fi
+                      echo "Waiting for MockServer..."
+                      sleep 1
+                    done
+                    echo "MockServer did not start in time"
+                    exit 1
+
+            -   name: Create mock server from our production OpenAPI
+                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://localhost:1080/mockserver/openapi
 
             -   name: Run tests
                 run: composer test
@@ -195,7 +107,7 @@ jobs:
         container: "node"
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v6
 
             -   name: Install dependencies
                 run: npm install

--- a/tests/Mocks/TheConfig.php
+++ b/tests/Mocks/TheConfig.php
@@ -22,6 +22,6 @@ class TheConfig extends \ThePay\ApiClient\TheConfig
      */
     public function getApiUrl()
     {
-        return 'http://openAPImock:1080/v1/';
+        return 'http://localhost:1080/v1/';
     }
 }


### PR DESCRIPTION
https://redmine.havelholding.cz/issues/6910

This upgrade of GitHub Actions was significantly more complicated than the previous ones.

PHP 7.4 and 8.0 are no longer supported in newer GitHub Actions due to the outdated Alpine version they rely on.
I no longer want to maintain the nofuture package, and I believe that using shivammathur/setup-php@v2 is a more practical and sustainable solution. It's also used in some of our other packages (e.g. cinzi-filament).

This PR appears to contain a large change, but that’s mainly because I rewrote the workflow using a matrix.
I did this to keep the configuration unified and easier to understand.

I recommend showing the new workflow separately because of the number of changes.

<img width="1430" height="855" alt="image" src="https://github.com/user-attachments/assets/464d43d4-428e-48ac-9378-bbcf621a1101" />
