### PR TITLE
6910 - Update GitHub Actions workflows in v3.x to use actions/checkout@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,159 +6,56 @@ on:
             - "**"
 
 jobs:
-    php82:
-        name: "php 8.2"
+    php-81-and-higher-tests:
+        name: php ${{ matrix.php-version }}
         runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.2"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']
+
         steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v3
-
-            -   name: Install dependencies
-                run: composer install --no-interaction
-            -   name: Old phpunit compatibility for php 8
-                run: composer require christiaanbye/polyfill-each --dev --no-interaction
-
-            # Disabled for now, fixer do not support PHP 8.2 yet.
-            #
-            #-   name: Check code style
-            #    run: composer cs-check
-
-            -   name: Run static analysis
-                run: composer stan
-
-            -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            -   name: Run tests
-                run: composer test81
-
-    php81:
-        name: "php 8.1"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.1"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-
-            - name: Install dependencies
-              run: composer install --no-interaction
-            - name: Old phpunit compatibility for php 8
-              run: composer require christiaanbye/polyfill-each --dev --no-interaction
-
-            - name: Check code style
-              run: composer cs-check
-
-            - name: Run static analysis
-              run: composer stan
-
-            - name: Create mock server from our production OpenAPI
-              run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            - name: Run tests
-              run: composer test81
-
-    php80:
-        name: "php 8.0"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:8.0"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-
-            - name: Install dependencies
-              run: composer install --no-interaction
-            - name: Old phpunit compatibility for php 8
-              run: composer require christiaanbye/polyfill-each --dev --no-interaction
-
-            - name: Check code style
-              run: composer cs-check
-
-            - name: Run static analysis
-              run: composer stan
-
-            - name: Create mock server from our production OpenAPI
-              run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            - name: Run tests
-              run: composer test
-
-    php74:
-        name: "php 7.4"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:7.4"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            # Deprecation example for future support removal.
-            #
-            #-   name: Deprecation check (2023-01-01T00:00:00+01:00)
-            #    run: if [ "$(date +%s)" -gt "1672527600" ]; then echo "This PHP version support ended"; exit1; else echo "Deprecation OK"; fi
+            -   name: Start mock server
+                run: docker run -d -p 1080:1080 mockserver/mockserver
 
             -   name: Checkout repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v6
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
-
-            -   name: Run static analysis
-                run: composer stan7
-
-            -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
-
-            -   name: Run tests
-                run: composer test
-
-    php72:
-        name: "php 7.2"
-        runs-on: ubuntu-latest
-        container: "nofutur3/php-tests:7.2"
-        services:
-            openAPImock:
-                image: mockserver/mockserver
-                ports:
-                    - 1080:1080
-        steps:
-            # Deprecation example for future support removal.
-            #
-            #-   name: Deprecation check (2023-01-01T00:00:00+01:00)
-            #    run: if [ "$(date +%s)" -gt "1672527600" ]; then echo "This PHP version support ended"; exit1; else echo "Deprecation OK"; fi
-
-            -   name: Checkout repository
-                uses: actions/checkout@v2
-
-            -   name: Composer update
-                run: composer self-update
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+                    coverage: none
+                    extensions: mbstring, intl, curl
 
             -   name: Install dependencies
                 run: composer install --no-interaction --no-security-blocking
 
-            -   name: Run static analysis
+            -   name: Old phpunit compatibility for php 8
+                if: startsWith(matrix.php-version, '8.')
+                run: composer require christiaanbye/polyfill-each --dev --no-interaction
+
+            -   name: Check code style (PHP 8.1)
+                if: matrix.php-version == '8.1'
+                run: composer cs-check
+
+            -   name: Run static analysis (PHP 8)
+                if: startsWith(matrix.php-version, '8.')
+                run: composer stan
+
+            -   name: Run static analysis (PHP 7)
+                if: startsWith(matrix.php-version, '7.')
                 run: composer stan7
 
             -   name: Create mock server from our production OpenAPI
-                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://openAPImock:1080/mockserver/openapi
+                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://localhost:1080/mockserver/openapi
 
-            -   name: Run tests
+            -   name: Run tests (PHP 8.1+)
+                if: startsWith(matrix.php-version, '8.') && matrix.php-version != '8.0'
+                run: composer test81
+
+            -   name: Run tests (PHP < 8.1)
+                if: "! (startsWith(matrix.php-version, '8.') && matrix.php-version != '8.0')"
                 run: composer test
 
     npm:
@@ -167,7 +64,7 @@ jobs:
         container: "node"
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v6
 
             -   name: Install dependencies
                 run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ on:
             - "**"
 
 jobs:
-    php-81-and-higher-tests:
+    php-tests:
         name: php ${{ matrix.php-version }}
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']
+                php-version: ['7.4', '8.0', '8.1', '8.3', '8.4', '8.5']
 
         steps:
             -   name: Start mock server
@@ -29,33 +29,55 @@ jobs:
                     extensions: mbstring, intl, curl
 
             -   name: Install dependencies
-                run: composer install --no-interaction --no-security-blocking
+                run: composer install --no-interaction
 
-            -   name: Old phpunit compatibility for php 8
-                if: startsWith(matrix.php-version, '8.')
-                run: composer require christiaanbye/polyfill-each --dev --no-interaction
-
-            -   name: Check code style (PHP 8.1)
-                if: matrix.php-version == '8.1'
+            -   name: Check code style (PHP 8.5)
+                if: matrix.php-version == '8.5'
                 run: composer cs-check
 
-            -   name: Run static analysis (PHP 8)
-                if: startsWith(matrix.php-version, '8.')
+            -   name: Run static analysis
                 run: composer stan
-
-            -   name: Run static analysis (PHP 7)
-                if: startsWith(matrix.php-version, '7.')
-                run: composer stan7
 
             -   name: Create mock server from our production OpenAPI
                 run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://localhost:1080/mockserver/openapi
 
-            -   name: Run tests (PHP 8.1+)
-                if: startsWith(matrix.php-version, '8.') && matrix.php-version != '8.0'
-                run: composer test81
+            -   name: Run tests
+                run: composer test
 
-            -   name: Run tests (PHP < 8.1)
-                if: "! (startsWith(matrix.php-version, '8.') && matrix.php-version != '8.0')"
+
+    php-with-psr-tests:
+        name: php ${{ matrix.php-version }} psr/http-message ${{ matrix.psr-http-message-version }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: ['8.2']
+                psr-http-message-version: ['1.0', '2.0']
+
+        steps:
+            -   name: Start mock server
+                run: docker run -d -p 1080:1080 mockserver/mockserver
+
+            -   name: Checkout repository
+                uses: actions/checkout@v6
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+                    coverage: none
+                    extensions: mbstring, intl, curl
+
+            -   name: Install dependencies
+                run: composer update --no-interaction --with psr/http-message:^${{ matrix.psr-http-message-version }}
+
+            -   name: Run static analysis
+                run: composer stan
+
+            -   name: Create mock server from our production OpenAPI
+                run: curl -X PUT -d "{\"specUrlOrPayload\":\"https://gate.thepay.cz/openapi.yaml\"}" http://localhost:1080/mockserver/openapi
+
+            -   name: Run tests
                 run: composer test
 
     npm:

--- a/tests/Mocks/TheConfig.php
+++ b/tests/Mocks/TheConfig.php
@@ -22,6 +22,6 @@ class TheConfig extends \ThePay\ApiClient\TheConfig
      */
     public function getApiUrl()
     {
-        return 'http://openAPImock:1080/v1/';
+        return 'http://localhost:1080/v1/';
     }
 }


### PR DESCRIPTION
https://redmine.havelholding.cz/issues/6910

CI is the same as CI in v2.

There was a conflict in the mocked TheConfig.php file. In V3 was added parameter `$specificVersion` which can change default API version.